### PR TITLE
close script tag on status page

### DIFF
--- a/doc/about/status.rst
+++ b/doc/about/status.rst
@@ -32,7 +32,8 @@ notebooks.gesis.org/binder
 
 .. raw:: html
 
-   <script src="../_static/status.js" type="text/javascript"/>
+   <script src="../_static/status.js" type="text/javascript">
+   </script>
 
 
 Running Binder sessions


### PR DESCRIPTION
not sure why self-closing tag gets its `/>` stripped by the theme, but it does