### PR TITLE
add curvenote to federation and supporters lists

### DIFF
--- a/doc/_data/support/federation.yml
+++ b/doc/_data/support/federation.yml
@@ -13,3 +13,10 @@
   funded_by_link: https://www.gesis.org/en/home
   run_by: GESIS Notebooks
   run_by_link: https://notebooks.gesis.org/about/
+
+- url_binderhub: https://binder.curvenote.dev
+  logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
+  funded_by: Curvenote
+  funded_by_link: https://curvenote.com
+  run_by: Curvenote
+  run_by_link: https://curvenote.com

--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -37,7 +37,7 @@ credits:
     url: https://www.gesis.org
 
   - name: Google Open Source
-    logo: https://www.gstatic.com/devrel-devsite/prod/v6cd15f45ec209c8961e07ea7e57ed9a0e9da4333bc915e67d1fcd2b2a9ec62d1/opensource/images/lockup.svg
+    logo: https://www.gstatic.com/devrel-devsite/prod/va65162e8ce9aacc75e4d3c0cd6d166fc6ceaaf184fea0ff0eac1d9b62c0480be/opensource/images/lockup.svg
     url: https://opensource.google/
 
   - name: OVHCloud

--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -28,13 +28,17 @@ financial: ''
 
 # Have provided cloud credits that power Binder infrastructure
 credits:
+  - name: Curvenote
+    logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
+    url: https://curvenote.com/
+
   - name: GESIS
     logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/gs_home_logo_de.svg
     url: https://www.gesis.org
 
-  - name: Curvenote
-    logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
-    url: https://curvenote.com/
+  - name: Google Open Source
+    logo: https://www.gstatic.com/devrel-devsite/prod/v6cd15f45ec209c8961e07ea7e57ed9a0e9da4333bc915e67d1fcd2b2a9ec62d1/opensource/images/lockup.svg
+    url: https://opensource.google/
 
   - name: OVHCloud
     logo: https://upload.wikimedia.org/wikipedia/commons/2/26/Logo-OVH.svg

--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -3,7 +3,7 @@
 # in an "official" capacity to Binder, not only if they do this off-hours.
 
 partners:
-  - name: 2i2c 
+  - name: 2i2c
     logo: https://github.com/2i2c-org/2i2c-org.github.io/blob/main/static/media/logo.png?raw=true
     url: https://2i2c.org
 
@@ -22,9 +22,9 @@ partners:
   - name: UC Berkeley
     logo: https://upload.wikimedia.org/wikipedia/commons/8/82/University_of_California%2C_Berkeley_logo.svg
     url: https://www.berkeley.edu/
- 
+
 # Have made substantial contributions to Binder in the last year (>$10,000)
-financial: ""
+financial: ''
 
 # Have provided cloud credits that power Binder infrastructure
 credits:
@@ -32,9 +32,9 @@ credits:
     logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/gs_home_logo_de.svg
     url: https://www.gesis.org
 
-  - name: Google Open Source
-    logo: https://www.gstatic.com/devrel-devsite/prod/v6cd15f45ec209c8961e07ea7e57ed9a0e9da4333bc915e67d1fcd2b2a9ec62d1/opensource/images/lockup.svg
-    url: https://opensource.google/
+  - name: Curvenote
+    logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
+    url: https://curvenote.com/
 
   - name: OVHCloud
     logo: https://upload.wikimedia.org/wikipedia/commons/2/26/Logo-OVH.svg

--- a/doc/_static/status.js
+++ b/doc/_static/status.js
@@ -1,8 +1,9 @@
 // in sync with list in status.rst
 // fixme: can this come from one source?
 var fedUrls = [
-  "https://ovh.mybinder.org",
-  "https://notebooks.gesis.org/binder",
+  'https://ovh.mybinder.org',
+  'https://notebooks.gesis.org/binder',
+  'https://binder.curvenote.dev',
 ];
 
 // Use a dictionary to store the rows that should be updated

--- a/doc/about/status.rst
+++ b/doc/about/status.rst
@@ -20,13 +20,14 @@ federation, along with the status of each. For more information about
 the BinderHub federation, who is in it, how to join it, etc, see
 `the mybinder federation page <https://mybinder.readthedocs.io/en/latest/about/federation.html>`_.
 
-.. update fedUrls in _status/status.js
+.. update fedUrls in _static/status.js
 
 ==========================  ========  ===============  ==============  =============== =====
   URL                       Response  Docker registry  JupyterHub API  User/Build Pods Quota
 ==========================  ========  ===============  ==============  =============== =====
 ovh.mybinder.org
 notebooks.gesis.org/binder
+binder.curvenote.dev
 ==========================  ========  ===============  ==============  =============== =====
 
 .. raw:: html


### PR DESCRIPTION
Updated the docs and status page to add the new curvenote instance to the federation listing (kudos to @manics for bringing it to life 🙌).

![image](https://github.com/jupyterhub/mybinder.org-user-guide/assets/1473646/0c4c6e70-fc44-40d5-84ad-f8f31b444b6e)


