### PR TITLE
BUG: fix name of default branch for edit-on-github

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,7 +83,7 @@ html_theme_options = {
 html_context = {
     "github_user": "jupyterhub",
     "github_repo": "binder",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "doc",
     "source_suffix": source_suffix,
 }


### PR DESCRIPTION
Edit on github wrongly points to the non-existing master branch