### PR TITLE
Fix more image logo

### DIFF
--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -33,7 +33,7 @@ credits:
     url: https://curvenote.com/
 
   - name: GESIS
-    logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/gs_home_logo_de.svg
+    logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/logo_gesis.svg
     url: https://www.gesis.org
 
   - name: Google Open Source

--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -37,7 +37,7 @@ credits:
     url: https://www.gesis.org
 
   - name: Google Open Source
-    logo: https://www.gstatic.com/devrel-devsite/prod/va65162e8ce9aacc75e4d3c0cd6d166fc6ceaaf184fea0ff0eac1d9b62c0480be/opensource/images/lockup.svg
+    logo: https://www.gstatic.com/devrel-devsite/prod/vec94db9b1329e6c4d1d9b6b24ba16ad6c02043dcd66ba9c6a8f3d8fa0af3eec7/opensource/images/lockup.svg
     url: https://opensource.google/
 
   - name: OVHCloud


### PR DESCRIPTION
This was reported by @arnim.

The page "[Supporting organizations](https://mybinder.readthedocs.io/en/latest/about/supporters.html)" is missing some logos.

Before

![Screenshot 2025-01-15 at 12-00-04 Supporting organizations — Binder 0 1b documentation](https://github.com/user-attachments/assets/2da02ded-89e8-4e45-83f8-668bc412cf8d)

After

![Screenshot 2025-01-15 at 11-59-46 Supporting organizations — Binder 0 1b documentation](https://github.com/user-attachments/assets/882f8c3f-22e8-4fc1-8886-775ec20bc27a)
