### PR TITLE
highlight past federation members, update some out of date supporters

### DIFF
--- a/doc/_data/scripts/gen_federation_md.py
+++ b/doc/_data/scripts/gen_federation_md.py
@@ -1,6 +1,7 @@
 """Generate snippets of markdown for various types of supporters.
 These are meant to be inserted into our docs.
 """
+
 from pathlib import Path
 from yaml import safe_load
 
@@ -12,9 +13,9 @@ template_binderhub = """
 :class-body: sd-p-4 sd-m-auto
 :class-card: bg-light
 :text-align: center
-:link: {URL_BINDERHUB}
+:link: {LINK}
 
-**{BINDERHUB_SUBDOMAIN}**
+**{TITLE}**
 
 ^^^
 
@@ -23,34 +24,57 @@ template_binderhub = """
 
 """
 
-# Read from our YAML data file 
+# Read from our YAML data file
 path_root = Path(__file__).parent.parent
 path_data = path_root / "support" / "federation.yml"
 binderhubs = safe_load(path_data.read_text())
 
-# Generate markdown entries for each federation member
-entries = []
-for binderhub in binderhubs:
-    entries.append(template_binderhub.format(URL_BINDERHUB=binderhub["url_binderhub"],
-        BINDERHUB_SUBDOMAIN=binderhub["url_binderhub"].split("//")[-1],
+
+def make_entry(binderhub: dict) -> str:
+    active = binderhub.get("active", True)
+    if active:
+        link = binderhub["url_binderhub"]
+    else:
+        link = binderhub["funded_by_link"]
+    return template_binderhub.format(
+        LINK=link,
+        TITLE=binderhub["url_binderhub"].split("//")[-1],
         LOGO=binderhub["logo"],
-        RUN_BY=binderhub["run_by"],
-        RUN_BY_LINK=binderhub["run_by_link"],
+        RUN_BY=binderhub.get("run_by", binderhub["funded_by"]),
+        RUN_BY_LINK=binderhub.get("run_by_link", binderhub["funded_by_link"]),
         FUNDED_BY=binderhub["funded_by"],
-        FUNDED_BY_LINK=binderhub["funded_by_link"],))
-entries = "\n".join(entries)
+        FUNDED_BY_LINK=binderhub["funded_by_link"],
+    )
+
+
+# Generate markdown entries for each federation member
+active_entries = []
+past_entries = []
+for binderhub in binderhubs:
+    entry = make_entry(binderhub)
+    if binderhub.get("active", True):
+        active_entries.append(entry)
+    else:
+        past_entries.append(entry)
 
 # Wrap the entries in a `grid` directive
-directive = f"""
+directive_template = """
 ````{{grid}} 1 1 2 2
 :class-container: federation-members
 :gutter: 4
 
-{entries}
+{ENTRIES}
 ````
 """
 
-# Write a txt file that we can insert into docs
-path_md = path_root.joinpath("snippets", "federation_md.txt")
-path_md.parent.mkdir(parents=True, exist_ok=True)
-path_md.write_text(directive)
+snippet_dir = path_root / "snippets"
+snippet_dir.mkdir(parents=True, exist_ok=True)
+for snippet_name, entries in [
+    ("federation_md.txt", active_entries),
+    ("federation_past_md.txt", past_entries),
+]:
+    # Write a txt file that we can insert into docs
+    directive = directive_template.format(ENTRIES="\n".join(entries))
+    path_md = snippet_dir / snippet_name
+    path_md.write_text(directive)
+    print(f"Wrote {len(entries)} entries to {path_md}")

--- a/doc/_data/support/federation.yml
+++ b/doc/_data/support/federation.yml
@@ -1,23 +1,44 @@
 # Data that is used to generate our federation page.
+# Alphabetical order
+# Instead of removing members, mark them as inactive with 'active: false'
 
 - url_binderhub: https://2i2c.mybinder.org
   logo: https://2i2c.org/media/logo.svg
   funded_by: 2i2c
   funded_by_link: https://2i2c.org
-  run_by: 2i2c
-  run_by_link: https://2i2c.org
+
+- url_binderhub: https://binder.curvenote.dev
+  logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
+  funded_by: Curvenote
+  funded_by_link: https://curvenote.com
+  active: false
+
+- url_binderhub: https://notebooks.gesis.org/binder
+  logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/logo_gesis.svg
+  funded_by: GESIS Leibniz Institute for the Social Sciences
+  funded_by_link: https://www.gesis.org/en/home
+
+- url_binderhub: https://gke.mybinder.org
+  logo: https://www.gstatic.com/devrel-devsite/prod/vec94db9b1329e6c4d1d9b6b24ba16ad6c02043dcd66ba9c6a8f3d8fa0af3eec7/opensource/images/lockup.svg
+  funded_by: Google Cloud
+  funded_by_link: https://opensource.google
+  run_by: Binder Team
+  run_by_link: https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team
+  active: false
 
 # Down, investigating. Discussing return now...
 - url_binderhub: https://ovh.mybinder.org
   logo: https://www.ovh.com/fr/images/logos/logo-ovh-twitter.jpg
   funded_by: OVHCloud
   funded_by_link: https://www.ovhcloud.com
-  run_by: OVH
-  run_by_link: https://www.ovhcloud.com
+  run_by: Binder Team
+  run_by_link: https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team
+  active: false
 
-- url_binderhub: https://notebooks.gesis.org/binder
-  logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/logo_gesis.svg
-  funded_by: GESIS Leibniz Institute for the Social Sciences 
-  funded_by_link: https://www.gesis.org/en/home
-  run_by: GESIS Leibniz Institute for the Social Sciences 
-  run_by_link: https://www.gesis.org/en/home
+- url_binderhub: https://turing.mybinder.org
+  logo: https://www.turing.ac.uk/sites/default/files/inline-images/Turing%20logo_0.png
+  funded_by: Alan Turing Institute
+  funded_by_link: https://turing.ac.uk
+  run_by: Turing Way team
+  run_by_link: https://www.turing.ac.uk/research/research-projects/turing-way-handbook-reproducible-data-science#organisers
+  active: false

--- a/doc/_data/support/supporters.yml
+++ b/doc/_data/support/supporters.yml
@@ -15,10 +15,6 @@ partners:
     logo: data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23F15922' viewBox='0 0 124 34' class='page-header__logo'%3E%3Cpath d='M101.099 1.084h-5.425v32.258h5.425zM22.475 3.834c0 2.013 1.666 3.717 3.642 3.717 2.054 0 3.643-1.704 3.643-3.717C29.76 1.704 28.171 0 26.117 0c-1.976 0-3.642 1.704-3.642 3.834M28.869 10.765h-5.425v22.577h5.425zM71.726 23.583c0 4.996.582 6.545 1.977 8.171 1.317 1.471 3.254 2.168 5.54 2.168 3.217 0 5.658-1.548 6.743-3.446v2.904h5.425V10.765h-5.425v12.082c0 3.64-1.472 6.274-4.844 6.274-1.898 0-2.944-.813-3.448-1.975-.543-1.2-.582-2.75-.582-4.376V10.765h-5.424v12.818zM51.228 12.392c-1.318-1.472-3.256-2.169-5.58-2.169-3.565 0-5.968 1.55-7.053 3.447v-2.905H33.17v22.577h5.425V21.26c0-3.64 1.55-6.274 4.883-6.274 4.068 0 4.378 2.827 4.378 6.932v11.424h5.425V21.26c0-3.64 1.511-6.274 4.883-6.274 4.069 0 4.378 2.827 4.378 6.932v11.424h5.426V20.524c0-4.996-.582-6.545-1.977-8.17-1.201-1.318-3.1-2.17-5.967-2.17-4.069 0-6.355 1.86-7.75 3.524-.388-.464-.698-.89-1.047-1.316M19.53 13.825c-1.473-1.627-4.921-3.602-9.455-3.602-4.301 0-9.106 2.091-9.106 7.01 0 4.143 3.1 5.77 7.014 6.621l3.37.697c2.17.465 3.45.775 3.45 2.324 0 1.626-1.55 2.555-4.263 2.555-3.449 0-5.657-1.665-6.936-3.369L0 29.315c1.395 1.937 5.038 4.609 10.424 4.609 5.154 0 9.881-2.479 9.881-7.63 0-4.143-3.1-5.42-6.51-6.195l-2.713-.62c-3.177-.658-4.727-1.007-4.727-2.594 0-1.472 1.55-2.246 3.72-2.246 2.596 0 4.805 1.045 6.355 2.556zM118.846 25.365c0 3.097-2.054 4.569-4.999 4.569-2.673 0-3.875-1.24-3.875-3.098 0-1.82 1.124-2.478 3.72-2.982l2.093-.426c1.627-.348 2.286-.503 3.1-.813v2.75zM124 28.19V17c0-4.995-3.798-6.622-8.951-6.622-5.425 0-9.959 2.246-9.882 7.784l5.077.348c-.039-2.672 1.511-3.95 4.572-3.95 2.79 0 4.03.93 4.03 2.827v.387c0 .852-.232.93-1.434 1.2l-4.998.853c-2.945.503-5.309 1.433-6.704 3.098-.814 1.007-1.279 2.285-1.279 3.988 0 4.918 3.604 7.126 7.983 7.126 3.875 0 5.425-1.937 6.394-2.905v2.169H124zq0 .06 0 0'%3E%3C/path%3E%3C/svg%3E
     url: https://www.simula.no
 
-  - name: The Turing Institute
-    logo: https://upload.wikimedia.org/wikipedia/commons/b/b5/Alan_Turing_Institute_logo.svg
-    url: https://www.turing.ac.uk/
-
   - name: UC Berkeley
     logo: https://upload.wikimedia.org/wikipedia/commons/8/82/University_of_California%2C_Berkeley_logo.svg
     url: https://www.berkeley.edu/
@@ -26,24 +22,28 @@ partners:
 # Have made substantial contributions to Binder in the last year (>$10,000)
 financial: ''
 
-# Have provided cloud credits that power Binder infrastructure
+# Have provided cloud credits that currently power Binder infrastructure
 credits:
-  - name: Curvenote
-    logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
-    url: https://curvenote.com/
+  - name: 2i2c
+    logo: https://github.com/2i2c-org/2i2c-org.github.io/blob/main/static/media/logo.png?raw=true
+    url: https://2i2c.org
+
+  # - name: Curvenote
+  #   logo: https://raw.githubusercontent.com/curvenote/brand/mybinder/logos/logo-text-blue.svg
+  #   url: https://curvenote.com/
 
   - name: GESIS
     logo: https://www.gesis.org/typo3conf/ext/gesis_web_ext/Resources/Public/webpack/dist/img/logo_gesis.svg
     url: https://www.gesis.org
 
-  - name: Google Open Source
-    logo: https://www.gstatic.com/devrel-devsite/prod/vec94db9b1329e6c4d1d9b6b24ba16ad6c02043dcd66ba9c6a8f3d8fa0af3eec7/opensource/images/lockup.svg
-    url: https://opensource.google/
-
-  - name: OVHCloud
-    logo: https://upload.wikimedia.org/wikipedia/commons/2/26/Logo-OVH.svg
-    url: https://www.ovhcloud.com/en/
-
-  - name: The Turing Institute
-    logo: https://upload.wikimedia.org/wikipedia/commons/b/b5/Alan_Turing_Institute_logo.svg
-    url: https://www.turing.ac.uk/
+#   - name: Google Open Source
+#     logo: https://www.gstatic.com/devrel-devsite/prod/vec94db9b1329e6c4d1d9b6b24ba16ad6c02043dcd66ba9c6a8f3d8fa0af3eec7/opensource/images/lockup.svg
+#     url: https://opensource.google/
+#
+#   - name: OVHCloud
+#     logo: https://upload.wikimedia.org/wikipedia/commons/2/26/Logo-OVH.svg
+#     url: https://www.ovhcloud.com/en/
+#
+#   - name: The Turing Institute
+#     logo: https://upload.wikimedia.org/wikipedia/commons/b/b5/Alan_Turing_Institute_logo.svg
+#     url: https://www.turing.ac.uk/

--- a/doc/about/federation.md
+++ b/doc/about/federation.md
@@ -23,6 +23,13 @@ Below is a list of the current member hubs in the BinderHub Federation:
 ```{include} /_data/snippets/federation_md.txt
 ```
 
+### Past members of the BinderHub Federation
+
+Thanks to past members of the BinderHub Federation, which are no longer active:
+
+```{include} /_data/snippets/federation_past_md.txt
+```
+
 
 (federation/joining)=
 ## Joining the BinderHub Federation

--- a/doc/about/supporters.md
+++ b/doc/about/supporters.md
@@ -22,5 +22,9 @@ Organizations that provide cloud credits that power the infrastructure behind my
 
 ## Previous grants and major support
 
+- [Curvenote](https://curvenote.com) sponsored a mybinder.org federation member in 2024
+- [OVHCloud](https://ovhcloud.com) sponsored a mybinder.org federation member in from 2019-2024
+- The [Alan Turing Institute](https://www.turing.ac.uk) operated a mybinder.org federation member from 2019 to 2023, and provided personnel support
+- [Google Open Source](https://opensource.google) supported Binder via cloud credits from 2017-2022
 - In 2017 the Binder Project received [a 1-year grant from the
 Moore Foundation](https://figshare.com/s/e9d0ad7bdc4e405cccfa).

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,8 +21,8 @@ def docs(session):
             "*/using/config_files.rst",
         ]
         cmd = ["sphinx-autobuild"]
-        for folder in AUTOBUILD_IGNORE:
-            cmd.extend(["--ignore", f"*/{folder}/*"])
+        for ignore in AUTOBUILD_IGNORE:
+            cmd.extend(["--ignore", ignore])
         cmd.extend(build_command)
         session.run(*cmd)
     else:


### PR DESCRIPTION
As [suggested on zulip](https://jupyter.zulipchat.com/#narrow/channel/103349-ask-anything/topic/Good.20bye.20to.20binder.2Ecurvenote.2Edev/near/499603807), preserves past federation members in a second list.

Also updates the 'support' page to move some no longer active support (Turing, Google, Curvenote, OVH) to the 'past support' section