### PR TITLE
Don't recommend using r-conda by default

### DIFF
--- a/doc/examples/sample_repos.md
+++ b/doc/examples/sample_repos.md
@@ -151,8 +151,6 @@ RShiny: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2
 Binder supports using R and RStudio, with libraries pinned to a specific
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).
 
-**Note:** We recommend to follow [r-conda](https://github.com/binder-examples/r-conda) instead. Especially if you want to use a specific version of R or need faster build times.
-
 **Note:** Another alternative is to use the [holepunch package for R](https://karthik.github.io/holepunch/articles/getting_started.html).
 
 ##### Requirements and suggestions


### PR DESCRIPTION
Almost everyone in the R ecosystem uses R directly without conda, and us recommending it causes confusing (see https://discourse.jupyter.org/t/error-in-mybinder-org-there-is-no-package-called-irkernel/32478). Let's fix issues with our R setup than recommend conda here.