### PR TITLE
Add JupyterCon banner and add Jupyter colors

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -6,11 +6,11 @@
 /* Header */
 
 .support-button {
-    background-color: #e66783;
+    background-color: var(--sd-color-secondary);
 }
 
 .support-button:hover {
-    background-color: #b9556b;
+    background-color: #bc7a3c;
 }
 
 .support-button i {

--- a/doc/_templates/support-button.html
+++ b/doc/_templates/support-button.html
@@ -1,1 +1,1 @@
-<a class="btn btn-secondary support-button" href="https://mybinder.readthedocs.io/en/latest/about/support.html" role="button"><i class="fas fa-heart"></i>Support Binder</a>
+<a class="btn support-button" href="https://mybinder.readthedocs.io/en/latest/about/support.html" role="button"><i class="fas fa-heart"></i>Support Binder</a>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,6 +55,7 @@ html_favicon = "_static/images/favicon.png"
 # documentation.
 #
 html_theme_options = {
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "use_edit_page_button": True,
     "analytics": {
         "google_analytics_id": "UA-101904940-3",
@@ -141,3 +142,4 @@ def setup(app):
     # Plausible.io tracking
     app.add_js_file("https://plausible.io/js/script.file-downloads.hash.outbound-links.js", **{"data-domain": "mybinder.readthedocs.io", "defer": ""})
     app.add_js_file(filename=None, body="window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }")
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,4 +142,5 @@ def setup(app):
     # Plausible.io tracking
     app.add_js_file("https://plausible.io/js/script.file-downloads.hash.outbound-links.js", **{"data-domain": "mybinder.readthedocs.io", "defer": ""})
     app.add_js_file(filename=None, body="window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }")
+    # Inherit some Jupyter branding CSS rules from the Jupyter Documentation
     app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")


### PR DESCRIPTION
This PR does a couple of things:

- Adds an announcement banner for JupyterCon
- Links a CSS file from the Jupyter documentation that we can use for jupyter colors in our docs
- Updates the support button to use the jupyter colors instead of the pink color